### PR TITLE
Use SteamOS's new official support

### DIFF
--- a/ui/widgets/library_row.py
+++ b/ui/widgets/library_row.py
@@ -12,13 +12,13 @@ class LibraryRow(Gtk.Box):
     def preview_video(self, _, url):
         PlaybackInterface(url)
 
-    def on_video_dl(_, __, url):
-        download_video(_, url)
+    def on_video_dl(_, __, url, title):
+        download_video(_, url, title)
         dialog = Gtk.MessageDialog(
             flags=0,
             message_type=Gtk.MessageType.INFO,
             buttons=Gtk.ButtonsType.OK,
-            text="Success ! Video is installed on your Steam Deck, reboot your device.",
+            text="Success ! Video is installed on your Steam Deck.",
         )
         dialog.run()
         dialog.destroy()
@@ -84,7 +84,7 @@ class LibraryRow(Gtk.Box):
             actions.set_spacing(6)
 
             download_button = Gtk.Button(label="Download")
-            download_button.connect('clicked', self.on_video_dl, boot_video["video"])
+            download_button.connect('clicked', self.on_video_dl, boot_video["video"], boot_video["title"])
             preview_button = Gtk.Button(label="Preview")
             preview_button.connect('clicked', self.preview_video, boot_video["video"])
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,7 +9,8 @@ CURRENT_VERSION = "1.0.8"
 
 
 def get_remote_version():
-    response = requests.get("https://raw.githubusercontent.com/CapitaineJSparrow/steam-repo-manager/main/flatpak/version.txt")
+    response = requests.get(
+        "https://raw.githubusercontent.com/CapitaineJSparrow/steam-repo-manager/main/flatpak/version.txt")
     return response.text.rstrip()
 
 
@@ -33,11 +34,11 @@ def clear_installed_videos(_=None):
         os.remove(f)
 
 
-def download_video(_, url: str):
+def download_video(_, url, title: str):
     print(f"Downloading {url}")
-    clear_installed_videos()
     response = requests.get(url)
-    open(os.path.join(Path(movies_path), "deck_startup.webm"), "wb").write(response.content)
+    # Replace "." symbol to avoid file format problem
+    open(os.path.join(Path(movies_path), title.replace(".", "") + ".webm"), "wb").write(response.content)
     override_default_length_library()
 
 


### PR DESCRIPTION
Updated to download multiple videos under the /home/deck/.steam/root/config/uioverrides/movies/ directory with their original name.